### PR TITLE
Ensure rasputin is initialized in all groups

### DIFF
--- a/lib/rasputin.rb
+++ b/lib/rasputin.rb
@@ -19,7 +19,7 @@ module Rasputin
     config.rasputin.use_javascript_require = true
     config.rasputin.strip_javascript_require = true
 
-    initializer :setup_rasputin do |app|
+    initializer :setup_rasputin, :group => :all do |app|
       app.assets.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
       app.assets.register_engine '.handlebars', Rasputin::HandlebarsTemplate
       app.assets.register_engine '.hbs', Rasputin::HandlebarsTemplate


### PR DESCRIPTION
Fixes the issue described here https://github.com/tchak/rasputin/issues/9 when `config.assets.initialize_on_precompile` is set to false. Other plugins/engines have been fixed in the same way: https://github.com/spohlenz/tinymce-rails/pull/23 and more info in the `initialize_on_precompile` rails commit here: https://github.com/lifo/docrails/commit/eb367afeed2905d1036f46940aa6c91323f7faab.
