### PR TITLE
Ability to customize path exclusions

### DIFF
--- a/lib/rasputin/handlebars/template.rb
+++ b/lib/rasputin/handlebars/template.rb
@@ -19,7 +19,8 @@ module Rasputin
     
     def template_path(path)
       path = path.split('/')
-      path.delete('templates')
+      exclusions = Array.wrap(Rails.configuration.rasputin.path_exclusions).compact.concat(["templates"])
+      path.reject! { |name| exclusions.include?(name) }
       path.join(Rails.configuration.rasputin.template_name_separator)
     end
 


### PR DESCRIPTION
An alternative would be this (which also makes it possible to remove the default exclusion, "templates"):

```
def template_path(path)
  path = path.split('/')
  exclusions = Array.wrap(Rails.configuration.rasputin.path_exclusions)
  path.reject! { |name| exclusions.include?(name) }
  path.join(Rails.configuration.rasputin.template_name_separator)
end


class Engine < ::Rails::Engine
  config.rasputin = ActiveSupport::OrderedOptions.new
  config.rasputin.precompile_handlebars = Rails.env.production?
  config.rasputin.template_name_separator = '/'
  config.rasputin.path_exclusions = ["templates"]

  config.rasputin.use_javascript_require = true
  config.rasputin.strip_javascript_require = true

  initializer :setup_rasputin, :group => :all do |app|
    app.assets.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
    app.assets.register_engine '.handlebars', Rasputin::HandlebarsTemplate
    app.assets.register_engine '.hbs', Rasputin::HandlebarsTemplate
  end
end
```
